### PR TITLE
Improve (lower) energy impact by reducing refresh rate

### DIFF
--- a/Classes/FanControl.m
+++ b/Classes/FanControl.m
@@ -222,7 +222,8 @@ NSString *authpw;
 
 	//release MachineDefaults class first call
 	//add timer for reading to RunLoop
-	_readTimer = [NSTimer scheduledTimerWithTimeInterval:3.0 target:self selector:@selector(readFanData:) userInfo:nil repeats:YES];
+	_readTimer = [NSTimer scheduledTimerWithTimeInterval:15.0 target:self selector:@selector(readFanData:) userInfo:nil repeats:YES];
+	[_readTimer setTolerance:5.0];
 	[_readTimer fire];
 	//autoapply settings if valid
 	[self upgradeFavorites];


### PR DESCRIPTION
Reduce refresh rate to 15 seconds and allow 5 seconds of tolerance for OS X to coalesce updates with other activities.

This change requires OS 10.9 or later.
