### PR TITLE
Adding missing define in header, fixes #21

### DIFF
--- a/smc-command/smc.h
+++ b/smc-command/smc.h
@@ -22,6 +22,7 @@
 #define __SMC_H__
 #endif
 
+#define CMD_TOOL
 #define VERSION               "0.01"
 
 #define OP_NONE               0


### PR DESCRIPTION
Working on Fix for compiler errors on OSX 10.9 and 10.10.