### PR TITLE
#65: repaired broken link to Cask in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ smcFanControl lets the user set a minimum speed for built-in fans. It allows you
 
 ## Installing it using Homebrew & Cask
 
-Make sure you have both [Homebrew](http://brew.sh/) and [Cask](http://caskroom.io/) installed. You'll find intructions to install both tools on their respective websites.
+Make sure you have both [Homebrew](http://brew.sh/) and [Cask](https://caskroom.github.io/) installed. You'll find intructions to install both tools on their respective websites.
 
 After installing Homebrew and Cask, run:
 


### PR DESCRIPTION
Simple fix! Thanks for all of the hard work on this!

http://caskroom.io appears to be depreciated, the current website appears to be https://caskroom.github.io/. Updated link in README.md. If accepted this resolves #65. Let me know if there's anything else needed!