### PR TITLE
smc: support writing FP values like fan speed (tested on MBP 16,1)

### DIFF
--- a/smc-command/smc.c
+++ b/smc-command/smc.c
@@ -648,6 +648,7 @@ void usage(char* prog)
     printf("    -k <key>   : key to manipulate\n");
     printf("    -l         : list all keys and values\n");
     printf("    -r         : read the value of a key\n");
+    printf("    -p <value> : write the specified integer value to a floating point key\n");
     printf("    -w <value> : write the specified value to a key\n");
     printf("    -v         : version\n");
     printf("\n");
@@ -684,7 +685,7 @@ int main(int argc, char *argv[])
     UInt32Char_t  key = { 0 };
     SMCVal_t      val;
     
-    while ((c = getopt(argc, argv, "fthk:lrw:v")) != -1)
+    while ((c = getopt(argc, argv, "fthk:lp:rw:v")) != -1)
     {
         switch(c)
         {
@@ -707,6 +708,17 @@ int main(int argc, char *argv[])
             case 'v':
                 printf("%s\n", VERSION);
                 return 0;
+                break;
+            case 'p':
+                op = OP_WRITE;
+                {
+                  float fval;
+                  fval = strtof(optarg, NULL);
+
+                  val.dataSize = 4;
+                  memcpy(val.bytes, &fval, sizeof(fval));
+                  memcpy(val.dataType, DATATYPE_FLT, sizeof(val.dataType));
+                }
                 break;
             case 'w':
                 op = OP_WRITE;


### PR DESCRIPTION
Needed to help with https://github.com/hholtmann/smcFanControl/issues/77 — to set fan speeds by hand.
TODO:
- [ ] update README

I've only tested this on my machine and I haven't programmed in C for a long while, but I've tried to be careful.

Example usage:
```
$ sudo ./smc -k F0Md -w 01
$ sudo ./smc -k F1Md -w 01
$ sudo ./smc -k F0Tg -p 3000
$ sudo ./smc -k F1Tg -p 3000
$ ./smc -f
Total fans in system: 2

Fan #0:
    Actual speed : 2980
    Minimum speed: 1836
    Maximum speed: 5297
    Safe speed   : 0
    Target speed : 3000
    Mode         : forced

Fan #1:
    Actual speed : 3007
    Minimum speed: 1700
    Maximum speed: 4905
    Safe speed   : 0
    Target speed : 3000
    Mode         : forced

$ ./smc -l|grep F.Tg
  F0Tg  [flt ]  3000 (bytes 00 80 3b 45)
  F1Tg  [flt ]  3000 (bytes 00 80 3b 45)
```