### PR TITLE
Fix cropped text in macOS Big Sur status bar

### DIFF
--- a/Classes/FanControl.m
+++ b/Classes/FanControl.m
@@ -447,7 +447,11 @@ NSUserDefaults *defaults;
             [paragraphStyle setAlignment:NSLeftTextAlignment];
             [s_status addAttribute:NSFontAttributeName value:[NSFont fontWithName:@"Lucida Grande" size:fsize] range:NSMakeRange(0,[s_status length])];
             [s_status addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:NSMakeRange(0,[s_status length])];
-         
+            [s_status addAttribute:NSBaselineOffsetAttributeName
+                           value:[NSNumber numberWithFloat: -6]
+                           range:NSMakeRange(0, s_status.length)];
+
+            [s_status addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:NSMakeRange(0,[s_status length])];
             if (setColor) [s_status addAttribute:NSForegroundColorAttributeName value:menuColor  range:NSMakeRange(0,[s_status length])];
             
            


### PR DESCRIPTION
This fixes the cropped out text when the "multiline" option is selected  (issue #109).