### PR TITLE
Change naming of "actual" to "current"

### DIFF
--- a/smc-command/README
+++ b/smc-command/README
@@ -42,7 +42,7 @@ To manually query and control:
 FNum - tells you how many fans are in the system
 
 To read data from each fan:
-F0Ac - Fan actual speed
+F0Ac - Fan current speed
 F0Mn - Fan minimum speed
 F0Mx - Fan maximum speed
 F0Sf - Fan safe speed

--- a/smc-command/smc.c
+++ b/smc-command/smc.c
@@ -564,7 +564,7 @@ kern_return_t SMCPrintFans(void)
         }
         sprintf(key, "F%cAc", fannum[i]);
         SMCReadKey(key, &val);
-        printf("    Actual speed : %.0f\n", getFloatFromVal(val));
+        printf("    Current speed : %.0f\n", getFloatFromVal(val));
         sprintf(key, "F%cMn", fannum[i]);
         SMCReadKey(key, &val);
         printf("    Minimum speed: %.0f\n", getFloatFromVal(val));


### PR DESCRIPTION
It is a typical "False Friend" often used by fellow Germans: https://de.wikipedia.org/wiki/Liste_falscher_Freunde#Englisch

This might break shell scripts that grep for `actual`.  So it might be a good choice to leave it as it is.