### PR TITLE
Fixed build error using Xcode 12 and Menu Bar formatting on Big Sur.

### DIFF
--- a/Classes/FanControl.m
+++ b/Classes/FanControl.m
@@ -447,6 +447,8 @@ NSUserDefaults *defaults;
             [paragraphStyle setAlignment:NSLeftTextAlignment];
             [s_status addAttribute:NSFontAttributeName value:[NSFont fontWithName:@"Lucida Grande" size:fsize] range:NSMakeRange(0,[s_status length])];
             [s_status addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:NSMakeRange(0,[s_status length])];
+            if (menuBarSetting == 0)
+                [s_status addAttribute:NSBaselineOffsetAttributeName value:[NSNumber numberWithFloat: -6] range:NSMakeRange(0, [s_status length])];
          
             if (setColor) [s_status addAttribute:NSForegroundColorAttributeName value:menuColor  range:NSMakeRange(0,[s_status length])];
             

--- a/smc-command/smc.h
+++ b/smc-command/smc.h
@@ -98,7 +98,7 @@ typedef struct {
 
 typedef unsigned char              SMCBytes_t[32];
 
-UInt8 fannum[] = "0123456789ABCDEFGHIJ";
+static UInt8 fannum[] = "0123456789ABCDEFGHIJ";
 
 typedef struct {
   UInt32                  key; 


### PR DESCRIPTION
1. **Build error:**
    duplicate symbol '_fannum'
    ld: 4 duplicate symbols for architecture x86_64

1. **Fixed formatting of menu bar on Big Sur**
    Corrected version of code from https://github.com/hholtmann/smcFanControl/pull/110.