### PR TITLE
Format README.md for smc-command

### DIFF
--- a/smc-command/README.md
+++ b/smc-command/README.md
@@ -1,8 +1,8 @@
 Warning
 -------
 This tool will allow you to write values to the SMC which could irreversably damage your
-computer.  Manipulating the fans could cause overheating and permanent damange.  USE THIS
-PROGRAM AT YOUR OWN RISK! 
+computer.  Manipulating the fans could cause overheating and permanent damange.  
+*USE THIS PROGRAM AT YOUR OWN RISK!*
 
 Background
 ----------
@@ -20,9 +20,12 @@ by running the fans at a low speed like 3500 RPM, which you can barely hear.
 
 Usage 
 ------
-# smc -h
+`smc -h`
 
+
+```bash
 Apple System Management Control (SMC) tool 0.01
+
 Usage:
 ./smc [options]
     -f         : fan info decoded
@@ -32,64 +35,69 @@ Usage:
     -r         : read the value of a key
     -w <value> : write the specified value to a key
     -v         : version
+```
 
 Fan control 
 -----------
-To decode:
-# smc -f
+To decode:  
+`smc -f`
 
 To manually query and control:
-FNum - tells you how many fans are in the system
+`FNum` - tells you how many fans are in the system
 
 To read data from each fan:
-F0Ac - Fan current speed
+```F0Ac - Fan current speed
 F0Mn - Fan minimum speed
 F0Mx - Fan maximum speed
 F0Sf - Fan safe speed
 F0Tg - Fan target speed
 FS!  - See if fans are in automatic or forced mode
+```
 
-[Replace 0 with fan #.  In the MacBook Pro there two fans so this applies for 0 (left)
- and 1 (right).]
+[Replace `0` with fan #.  In the MacBook Pro there two fans so this applies for `0` (left)
+ and `1` (right).]
 
 To set a fan to a specific speed:
-FS!  - Sets "force mode" to fan.  Bit 0 (right to left) is fan 0, bit 1
-       is fan 1, etc
-F0Tg - Sets target speed, make sure you fp78 encode it (left shift by 2)
 
-For example, to force both fans to 3500 RPM:
-# python -c "print hex(3500 << 2)"
+`FS!`  Sets "force mode" to fan.  
+    - Bit 0 (right to left) is fan 0, bit 1 is fan 1, etc.  
+`F0Tg` - Sets target speed, make sure you fp78 encode it (left shift by 2)
+
+
+For example, to force both fans to 3500 RPM:  
+`python -c "print hex(3500 << 2)"`
 0x36b0
-# smc -k "FS! " -w 0003
-# smc -k F0Tg -w 36b0
-# smc -k F1Tg -w 36b0
 
-..to force fan 0 to 4000 RPM and leave fan 1 in automatic mode:
-# smc -k "FS! " -w 0001
-# smc -k F0Tg -w 3e80
+`smc -k "FS! " -w 0003`    
+`smc -k F0Tg -w 36b0`    
+`smc -k F1Tg -w 36b0`
 
-..to return both fans to automatic mode:
-# smc -k "FS! " -w 0000
+..to force fan 0 to 4000 RPM and leave fan 1 in automatic mode:  
+`smc -k "FS! " -w 0001`  
+`smc -k F0Tg -w 3e80` 
+
+..to return both fans to automatic mode:  
+`smc -k "FS! " -w 0000`
 
 Temperature sensors
 -------------------
-TB0T
-TC0D
-TC0P
-TM0P
-TN0P
-Th0H
-Ts0P
-TN1P
+TB0T   
+TC0D  
+TC0P  
+TM0P  
+TN0P  
+Th0H  
+Ts0P  
+TN1P  
 Th1H
 
 Light sensors
 -------------
-ALV0 - Left 
+ALV0 - Left   
 ALV1 - Right 
 
 Motion sensors
 --------------
-MO_X
-MO_Y
+MO_X  
+MO_Y  
 MO_Z

--- a/smc-command/README.md
+++ b/smc-command/README.md
@@ -42,7 +42,7 @@ Fan control
 To decode:  
 `smc -f`
 
-To manually query and control:
+To manually query and control:  
 `FNum` - tells you how many fans are in the system
 
 To read data from each fan:


### PR DESCRIPTION
The existing README looked good, but wasn't displaying properly without the `.md` extension.

I renamed it to `README.md` and reformatted a bit.

Cheers