### PR TITLE
Fix literal '~' in Release config SYMROOT

### DIFF
--- a/smcFanControl.xcodeproj/project.pbxproj
+++ b/smcFanControl.xcodeproj/project.pbxproj
@@ -608,7 +608,7 @@
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "";
 				SDKROOT = macosx;
-				SYMROOT = "~/builds";
+				SYMROOT = "$(HOME)/builds";
 				VALID_ARCHS = "arm64e arm64 i386 x86_64";
 			};
 			name = Release;


### PR DESCRIPTION
I was building the `smc` scheme via `xcodebuild` in the CLI with `-configuration Release`, and I realized that the output binary was going into a literal `~` directory within the working dir, instead of the user's homedir. This just updates the `~` to use `$(HOME)` like the other schemes are configured.