### PR TITLE
fix: Copy functionality works better

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ Make sure you have both [Homebrew](http://brew.sh/) and [Cask](https://caskroom.
 After installing Homebrew and Cask, run:
 
 ```
-$ brew install --cask smcfancontrol
+brew install --cask smcfancontrol
 ```
 
 After that you'll be able to use Spotlight to launch smcFanControl normally. :-)


### PR DESCRIPTION
When you try to copy-paste - it'll copy $ sign, which is wrong

![image](https://github.com/hholtmann/smcFanControl/assets/563412/0913a34b-6d07-464d-93d5-edbc8b538f06)
