### PR TITLE
Add notice pointing to community-maintained fork

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,7 @@
 # smcFanControl
 
+> **Note:** This repository is no longer actively maintained. A community-maintained fork is available at [smcFanControl Community Edition](https://github.com/wolffcatskyy/smcFanControl) with fixes for deprecated macOS APIs and merged community PRs.
+
 smcFanControl lets the user set a minimum speed for built-in fans. It allows you to increase your minimum fan speed to make your Intel Mac run cooler. In order to not damage your machine, smcFanControl does not let you set a minimum speed to a value below Apple's defaults.
 
 ![My image](https://www.eidac.de/smc_screenshot.png)


### PR DESCRIPTION
Hi @hholtmann — thank you for creating and maintaining smcFanControl over the years. It's been an invaluable tool for Mac users who want better control over their fans.

Since this repository hasn't seen updates in a while, I've been maintaining a community fork at [wolffcatskyy/smcFanControl](https://github.com/wolffcatskyy/smcFanControl) to keep the project alive for Intel Mac users. The fork includes:

- **Fixes for 16 deprecated macOS APIs** that cause warnings and potential issues on newer macOS versions
- **Merged community PRs** that have been waiting here (#143, #146, #108)
- **Removed dead code** (Sparkle auto-updater pointing to defunct eidac.de, donation prompts, unused classes)

This PR adds a note at the top of the README pointing users to the actively maintained fork. No other changes.

Happy to adjust wording if you'd prefer something different.

🤖 *This PR was created by Claude AI assisting the maintainer.*